### PR TITLE
VIDCS-738: Update OPENTOK version on mac-sdk-samples

### DIFF
--- a/OpenTokSDKVersion.rb
+++ b/OpenTokSDKVersion.rb
@@ -1,2 +1,2 @@
-OpenTokSDKVersion = '2.24.0'
+OpenTokSDKVersion = '2.25.0'
 MinMacOSVersion = '10.13.0'


### PR DESCRIPTION
Hi, OPENTOK version is updated using 2.25.0 in this pr.