### PR TITLE
VIDCS-886 : Update opentok-macos-sdk-samples to use 2.25.1

### DIFF
--- a/OpenTokSDKVersion.rb
+++ b/OpenTokSDKVersion.rb
@@ -1,2 +1,2 @@
-OpenTokSDKVersion = '2.24.0'
-MinMacOSVersion = '10.13.0'
+OpenTokSDKVersion = '2.25.1'
+MinMacOSVersion = '10.15.0'


### PR DESCRIPTION
OpenTok SDK version and MinMacOS version were updated .